### PR TITLE
Provide a binary from this package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Trasnlates TipRanks angular code around",
   "main": "extract-json.js",
+  "bin": "translator.js",
   "dependencies": {
     "bluebird": "^2.3.2",
     "cheerio": "^0.17.0",


### PR DESCRIPTION
The added line in the package.json allows the package to be installed as a binary. i.e. we'll be able to run `tipranksTranslator` from the terminal to run it, in any project.
